### PR TITLE
Simplify payload

### DIFF
--- a/lnurl/pay.go
+++ b/lnurl/pay.go
@@ -76,20 +76,14 @@ func (l *LnurlPayRouter) HandleInfo(w http.ResponseWriter, r *http.Request) {
 	}
 
 	callbackURL := fmt.Sprintf("%v/lnurlpay/%v/%v/invoice", l.rootURL.String(), pubkey, hookKeyHash)
-	request := LnurlPayWebhookPayload{
+	message := channel.WebhookMessage{
 		Template: "lnurlpay_info",
 		Data: map[string]interface{}{
-			"lnurlpay_info": map[string]interface{}{
-				"callback_url": callbackURL,
-			},
+			"callback_url": callbackURL,
 		},
 	}
-	jsonBytes, err := json.Marshal(request)
-	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	response, err := l.channel.SendRequest(r.Context(), webhook.Url, "lnurlpay_info", string(jsonBytes), w)
+
+	response, err := l.channel.SendRequest(r.Context(), webhook.Url, message, w)
 	if r.Context().Err() != nil {
 		return
 	}
@@ -133,20 +127,13 @@ func (l *LnurlPayRouter) HandleInvoice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	request := LnurlPayWebhookPayload{
+	message := channel.WebhookMessage{
 		Template: "lnurlpay_invoice",
 		Data: map[string]interface{}{
-			"lnurlpay_invoice": map[string]interface{}{
-				"amount": amountNum,
-			},
+			"amount": amountNum,
 		},
 	}
-	jsonBytes, err := json.Marshal(request)
-	if err != nil {
-		http.Error(w, "internal error", http.StatusInternalServerError)
-		return
-	}
-	response, err := l.channel.SendRequest(r.Context(), webhook.Url, "lnurlpay_invoice", string(jsonBytes), w)
+	response, err := l.channel.SendRequest(r.Context(), webhook.Url, message, w)
 	if r.Context().Err() != nil {
 		return
 	}

--- a/server_test.go
+++ b/server_test.go
@@ -53,11 +53,15 @@ func setupHookServer(t *testing.T) {
 	callbackRouter := mux.NewRouter()
 	callbackRouter.HandleFunc("/callback", func(w http.ResponseWriter, r *http.Request) {
 		allBody, _ := io.ReadAll(r.Body)
-		var payload channel.WebhookChannelRequestPayload
+		var payload channel.WebhookMessage
 		if err := json.Unmarshal(allBody, &payload); err != nil {
 			t.Errorf("unmarshal proxy payload, expected no error, got %v", err)
 		}
-		response, err := http.Post(payload.Data.CallbackURL, "application/json", bytes.NewBuffer([]byte(`{"status": "ok"}`)))
+		replyURL, ok := payload.Data["reply_url"].(string)
+		if !ok {
+			t.Errorf("failed to extract reply_url %+v", payload)
+		}
+		response, err := http.Post(replyURL, "application/json", bytes.NewBuffer([]byte(`{"status": "ok"}`)))
 		if err != nil {
 			t.Errorf("failed to invoke hook callback %v", err)
 		}


### PR DESCRIPTION
Instead of wrapping the internal lnurlpay structures with the callback channel structure we now flatten the whole payload to a simple structure (template, data) so it would be easier to process all payload types on the receiver.
In practice it turns out a lot simpler than before.