### PR TITLE
Add username registration and lightning address handling

### DIFF
--- a/lnurl/pay.go
+++ b/lnurl/pay.go
@@ -20,6 +20,12 @@ import (
 	"github.com/gorilla/mux"
 )
 
+const (
+	// https://datatracker.ietf.org/doc/html/rfc5322#section-3.4.1
+	// https://stackoverflow.com/a/201378
+	USERNAME_VALIDATION_REGEX = "^(?:[a-zA-Z0-9!#$%&'*+\\/=?^_`{|}~-]+(?:\\.[a-z0-9!#$%&'*+\\/=?^_`{|}~-]+)*|\"(?:[\x01-\x08\x0b\x0c\x0e-\x1f\x21\x23-\x5b\x5d-\x7f]|\\[\x01-\x09\x0b\x0c\x0e-\x7f])*\")$"
+)
+
 type RegisterLnurlPayRequest struct {
 	Username   *string `json:"username"`
 	Time       int64   `json:"time"`
@@ -35,7 +41,7 @@ type RegisterLnurlPayResponse struct {
 func (w *RegisterLnurlPayRequest) Verify(pubkey string) error {
 	messageToVerify := fmt.Sprintf("%v-%v", w.Time, w.WebhookUrl)
 	if w.Username != nil {
-		if ok, err := regexp.MatchString("^\\w+$", *w.Username); !ok || err != nil {
+		if ok, err := regexp.MatchString(USERNAME_VALIDATION_REGEX, *w.Username); !ok || err != nil {
 			return fmt.Errorf("invalid username")
 		}
 		messageToVerify = fmt.Sprintf("%v-%v", messageToVerify, *w.Username)

--- a/lnurl/pay.go
+++ b/lnurl/pay.go
@@ -8,6 +8,7 @@ import (
 	"math"
 	"net/http"
 	"net/url"
+	"regexp"
 	"strconv"
 	"time"
 
@@ -20,20 +21,25 @@ import (
 )
 
 type RegisterLnurlPayRequest struct {
-	Time       int64  `json:"time"`
-	WebhookUrl string `json:"webhook_url"`
-	Signature  string `json:"signature"`
+	Username   *string `json:"username"`
+	Time       int64   `json:"time"`
+	WebhookUrl string  `json:"webhook_url"`
+	Signature  string  `json:"signature"`
 }
 
 type RegisterLnurlPayResponse struct {
-	Lnurl string `json:"lnurl"`
+	Lnurl            string  `json:"lnurl"`
+	LightningAddress *string `json:"lightning_address,omitempty"`
 }
 
 func (w *RegisterLnurlPayRequest) Verify(pubkey string) error {
-	if math.Abs(float64(time.Now().Unix()-w.Time)) > 30 {
-		return errors.New("invalid time")
-	}
 	messageToVerify := fmt.Sprintf("%v-%v", w.Time, w.WebhookUrl)
+	if w.Username != nil {
+		if ok, err := regexp.MatchString("^\\w+$", *w.Username); !ok || err != nil {
+			return fmt.Errorf("invalid username")
+		}
+		messageToVerify = fmt.Sprintf("%v-%v", messageToVerify, *w.Username)
+	}
 	verifiedPubkey, err := lightning.VerifyMessage([]byte(messageToVerify), w.Signature)
 	if err != nil {
 		return err
@@ -102,8 +108,9 @@ func RegisterLnurlPayRouter(router *mux.Router, rootURL *url.URL, store persist.
 	}
 	router.HandleFunc("/lnurlpay/{pubkey}", lnurlPayRouter.Register).Methods("POST")
 	router.HandleFunc("/lnurlpay/{pubkey}", lnurlPayRouter.Unregister).Methods("DELETE")
-	router.HandleFunc("/lnurlp/{pubkey}", lnurlPayRouter.HandleLnurlPay).Methods("GET")
-	router.HandleFunc("/lnurlpay/{pubkey}/invoice", lnurlPayRouter.HandleInvoice).Methods("GET")
+	router.HandleFunc("/.well-known/lnurlp/{identifier}", lnurlPayRouter.HandleLnurlPay).Methods("GET")
+	router.HandleFunc("/lnurlp/{identifier}", lnurlPayRouter.HandleLnurlPay).Methods("GET")
+	router.HandleFunc("/lnurlpay/{identifier}/invoice", lnurlPayRouter.HandleInvoice).Methods("GET")
 }
 
 /*
@@ -130,9 +137,10 @@ func (s *LnurlPayRouter) Register(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, "invalid signature", http.StatusUnauthorized)
 		return
 	}
-	err := s.store.Set(r.Context(), persist.Webhook{
-		Pubkey: pubkey,
-		Url:    addRequest.WebhookUrl,
+	webhook, err := s.store.Set(r.Context(), persist.Webhook{
+		Pubkey:   pubkey,
+		Username: addRequest.Username,
+		Url:      addRequest.WebhookUrl,
 	})
 
 	if err != nil {
@@ -153,8 +161,14 @@ func (s *LnurlPayRouter) Register(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)
 		return
 	}
+	var lightningAddress *string
+	if webhook.Username != nil {
+		lnAddr := fmt.Sprintf("%v@%v", *webhook.Username, s.rootURL.Host)
+		lightningAddress = &lnAddr
+	}
 	body, err := json.Marshal(RegisterLnurlPayResponse{
-		Lnurl: lnurl,
+		Lnurl:            lnurl,
+		LightningAddress: lightningAddress,
 	})
 	if err != nil {
 		w.WriteHeader(http.StatusInternalServerError)
@@ -207,14 +221,14 @@ HandleLnurlPay handles the initial request of lnurl pay protocol.
 */
 func (l *LnurlPayRouter) HandleLnurlPay(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	pubkey, ok := params["pubkey"]
+	identifier, ok := params["identifier"]
 	if !ok {
 		log.Println("invalid params, err")
 		http.Error(w, "unexpected error", http.StatusInternalServerError)
 		return
 	}
 
-	webhook, err := l.store.GetLastUpdated(r.Context(), pubkey)
+	webhook, err := l.store.GetLastUpdated(r.Context(), identifier)
 	if err != nil {
 		writeJsonResponse(w, NewLnurlPayErrorResponse("lnurl not found"))
 		return
@@ -224,7 +238,7 @@ func (l *LnurlPayRouter) HandleLnurlPay(w http.ResponseWriter, r *http.Request) 
 		return
 	}
 
-	callbackURL := fmt.Sprintf("%v/lnurlpay/%v/invoice", l.rootURL.String(), webhook.Pubkey)
+	callbackURL := fmt.Sprintf("%v/lnurlpay/%v/invoice", l.rootURL.String(), identifier)
 	message := channel.WebhookMessage{
 		Template: "lnurlpay_info",
 		Data: map[string]interface{}{
@@ -249,7 +263,7 @@ HandleInvoice handles the seconds request of lnurl pay protocol.
 */
 func (l *LnurlPayRouter) HandleInvoice(w http.ResponseWriter, r *http.Request) {
 	params := mux.Vars(r)
-	pubkey, ok := params["pubkey"]
+	identifier, ok := params["identifier"]
 	if !ok {
 		log.Println("invalid params, err")
 		http.Error(w, "unexpected error", http.StatusInternalServerError)
@@ -267,7 +281,7 @@ func (l *LnurlPayRouter) HandleInvoice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	webhook, err := l.store.GetLastUpdated(r.Context(), pubkey)
+	webhook, err := l.store.GetLastUpdated(r.Context(), identifier)
 	if err != nil {
 		writeJsonResponse(w, NewLnurlPayErrorResponse("lnurl not found"))
 		return

--- a/lnurl/pay_test.go
+++ b/lnurl/pay_test.go
@@ -1,0 +1,84 @@
+package lnurl
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"log"
+	"testing"
+	"time"
+
+	"github.com/breez/lspd/lightning"
+	"github.com/btcsuite/btcd/btcec/v2/ecdsa"
+	"github.com/decred/dcrd/dcrec/secp256k1/v4"
+	"github.com/tv42/zbase32"
+	"gotest.tools/assert"
+)
+
+func TestPayRegisterLnurlPayRequestValidUsername(t *testing.T) {
+	url := "http://localhost:8080/callback"
+	time := time.Now().Unix()
+	privKey, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		t.Errorf("failed to generate private key %v", err)
+	}
+	pubkey := privKey.PubKey()
+	serializedPubkey := hex.EncodeToString(pubkey.SerializeCompressed())
+
+	// Test valid usernames
+	validUsernames := []string{"testuser", "test.user", "test#user", "test{user}", "test+user"}
+
+	for _, validUsername := range validUsernames {
+		messgeToSign := fmt.Sprintf("%v-%v-%v", time, url, validUsername)
+		msg := append(lightning.SignedMsgPrefix, []byte(messgeToSign)...)
+		first := sha256.Sum256([]byte(msg))
+		second := sha256.Sum256(first[:])
+		sig, err := ecdsa.SignCompact(privKey, second[:], true)
+		if err != nil {
+			t.Errorf("failed to sign signature %v", err)
+		}
+		payRequest := RegisterLnurlPayRequest{
+			Username:   &validUsername,
+			Time:       time,
+			WebhookUrl: url,
+			Signature:  zbase32.EncodeToString(sig),
+		}
+		log.Printf("username: %v", *payRequest.Username)
+		err = payRequest.Verify(serializedPubkey)
+		assert.NilError(t, err, "should be able a valid username")
+	}
+}
+
+func TestPayRegisterLnurlPayRequestInvalidUsername(t *testing.T) {
+	url := "http://localhost:8080/callback"
+	time := time.Now().Unix()
+	privKey, err := secp256k1.GeneratePrivateKey()
+	if err != nil {
+		t.Errorf("failed to generate private key %v", err)
+	}
+	pubkey := privKey.PubKey()
+	serializedPubkey := hex.EncodeToString(pubkey.SerializeCompressed())
+
+	// Test invalid usernames
+	invalidUsernames := []string{"testuser.", ".testuser", "test..user", "test(user", "test≠user"}
+
+	for _, invalidUsername := range invalidUsernames {
+		messgeToSign := fmt.Sprintf("%v-%v-%v", time, url, invalidUsername)
+		msg := append(lightning.SignedMsgPrefix, []byte(messgeToSign)...)
+		first := sha256.Sum256([]byte(msg))
+		second := sha256.Sum256(first[:])
+		sig, err := ecdsa.SignCompact(privKey, second[:], true)
+		if err != nil {
+			t.Errorf("failed to sign signature %v", err)
+		}
+		payRequest := RegisterLnurlPayRequest{
+			Username:   &invalidUsername,
+			Time:       time,
+			WebhookUrl: url,
+			Signature:  zbase32.EncodeToString(sig),
+		}
+		log.Printf("username: %v", *payRequest.Username)
+		err = payRequest.Verify(serializedPubkey)
+		assert.ErrorContains(t, err, "invalid username")
+	}
+}

--- a/lnurl/pay_test.go
+++ b/lnurl/pay_test.go
@@ -16,7 +16,8 @@ import (
 )
 
 func TestPayRegisterLnurlPayRequestValidUsername(t *testing.T) {
-	url := "http://localhost:8080/callback"
+	domain := "lnurl.domain"
+	url := fmt.Sprintf("http://%v/callback", domain)
 	time := time.Now().Unix()
 	privKey, err := secp256k1.GeneratePrivateKey()
 	if err != nil {
@@ -26,7 +27,14 @@ func TestPayRegisterLnurlPayRequestValidUsername(t *testing.T) {
 	serializedPubkey := hex.EncodeToString(pubkey.SerializeCompressed())
 
 	// Test valid usernames
-	validUsernames := []string{"testuser", "test.user", "test#user", "test{user}", "test+user"}
+	validUsernames := []string{
+		"testuser",
+		"test.user",
+		"test#user",
+		"test{user}",
+		"test+user",
+		"this________username________is________not________too________long",
+	}
 
 	for _, validUsername := range validUsernames {
 		messgeToSign := fmt.Sprintf("%v-%v-%v", time, url, validUsername)
@@ -50,7 +58,8 @@ func TestPayRegisterLnurlPayRequestValidUsername(t *testing.T) {
 }
 
 func TestPayRegisterLnurlPayRequestInvalidUsername(t *testing.T) {
-	url := "http://localhost:8080/callback"
+	domain := "lnurl.domain"
+	url := fmt.Sprintf("http://%v/callback", domain)
 	time := time.Now().Unix()
 	privKey, err := secp256k1.GeneratePrivateKey()
 	if err != nil {
@@ -60,7 +69,14 @@ func TestPayRegisterLnurlPayRequestInvalidUsername(t *testing.T) {
 	serializedPubkey := hex.EncodeToString(pubkey.SerializeCompressed())
 
 	// Test invalid usernames
-	invalidUsernames := []string{"testuser.", ".testuser", "test..user", "test(user", "test≠user"}
+	invalidUsernames := []string{
+		"testuser.",
+		".testuser",
+		"test..user",
+		"test(user",
+		"test≠user",
+		"this___________username___________is___________too___________long",
+	}
 
 	for _, invalidUsername := range invalidUsernames {
 		messgeToSign := fmt.Sprintf("%v-%v-%v", time, url, invalidUsername)

--- a/persist/migrations/000002_pubkey_usernames.down.sql
+++ b/persist/migrations/000002_pubkey_usernames.down.sql
@@ -1,0 +1,2 @@
+DROP INDEX if exists lnurl_pubkey_usernames_username_uk;
+DROP TABLE if exists public.lnurl_pubkey_usernames;

--- a/persist/migrations/000002_pubkey_usernames.up.sql
+++ b/persist/migrations/000002_pubkey_usernames.up.sql
@@ -1,0 +1,6 @@
+CREATE TABLE public.lnurl_pubkey_usernames (
+	pubkey bytea PRIMARY KEY,  
+	username varchar NOT NULL
+);
+
+CREATE UNIQUE INDEX lnurl_pubkey_usernames_username_uk ON public.lnurl_pubkey_usernames (username);

--- a/persist/pg.go
+++ b/persist/pg.go
@@ -3,10 +3,13 @@ package persist
 import (
 	"context"
 	"encoding/hex"
+	"errors"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
@@ -22,10 +25,47 @@ func NewPgStore(databaseUrl string) (*PgStore, error) {
 	return &PgStore{pool: pool}, nil
 }
 
-func (s *PgStore) Set(ctx context.Context, webhook Webhook) error {
+func (s *PgStore) Set(ctx context.Context, webhook Webhook) (*Webhook, error) {
 	pk, err := hex.DecodeString(webhook.Pubkey)
 	if err != nil {
-		return err
+		return nil, err
+	}
+	pubkeyUsername, err := s.getPubkeyUsername(ctx, pk)
+	if err != nil {
+		return nil, err
+	}
+	if webhook.Username != nil {
+		// The set request includes a username. Insert the username for the pubkey if no record
+		// was found, otherwise update the pubkey's record with the new username. 
+		// If another record already uses this username, there will be an error returned.
+		username := strings.ToLower(*webhook.Username)
+		var res pgconn.CommandTag
+		if pubkeyUsername == nil {
+			res, err = s.pool.Exec(
+				ctx,
+				`INSERT INTO public.lnurl_pubkey_usernames (pubkey, username) values ($1, $2)`,
+				pk,
+				username,
+			)
+			webhook.Username = &username
+		} else {
+			res, err = s.pool.Exec(
+				ctx,
+				`UPDATE public.lnurl_pubkey_usernames SET username = $2 WHERE pubkey = $1`,
+				pk,
+				username,
+			)
+			pubkeyUsername.Username = username
+		}
+		if err != nil {
+			return nil, fmt.Errorf("invalid username: %v", *webhook.Username)
+		}
+		if res.RowsAffected() == 0 {
+			return nil, fmt.Errorf("failed to set username for pubkey: %v", webhook.Pubkey)
+		}
+	}
+	if pubkeyUsername != nil {
+		webhook.Username = &pubkeyUsername.Username
 	}
 
 	now := time.Now().UnixMicro()
@@ -40,26 +80,27 @@ func (s *PgStore) Set(ctx context.Context, webhook Webhook) error {
 		now,
 	)
 	if err != nil {
-		return err
-	}
-	if res.RowsAffected() == 0 {
-		return fmt.Errorf("failed to set webhook for pubkey: %v", webhook.Pubkey)
-	}
-	return err
-}
-
-func (s *PgStore) GetLastUpdated(ctx context.Context, pubkey string) (*Webhook, error) {
-	pk, err := hex.DecodeString(pubkey)
-	if err != nil {
 		return nil, err
 	}
+	if res.RowsAffected() == 0 {
+		return nil, fmt.Errorf("failed to set webhook for pubkey: %v", webhook.Pubkey)
+	}
+	return &webhook, err
+}
 
+func (s *PgStore) GetLastUpdated(ctx context.Context, identifier string) (*Webhook, error) {
+	pk := decodeIdentifier(identifier)
+
+	// Get the webhook record by the identifier which can either a decoded pubkey or username. 
 	rows, err := s.pool.Query(
 		ctx,
-		`SELECT encode(pubkey,'hex') pubkey, url 
-		 FROM public.lnurl_webhooks
-		 WHERE pubkey = $1 order by refreshed_at desc limit 1`,
+		`SELECT encode(lw.pubkey, 'hex') pubkey, lpu.username, lw.url 
+		 FROM public.lnurl_webhooks lw
+         LEFT JOIN public.lnurl_pubkey_usernames lpu ON lw.pubkey = lpu.pubkey
+		 WHERE lw.pubkey = $1 OR lpu.username = $2
+		 ORDER BY lw.refreshed_at DESC LIMIT 1`,
 		pk,
+		strings.ToLower(identifier),
 	)
 
 	if err != nil {
@@ -71,7 +112,7 @@ func (s *PgStore) GetLastUpdated(ctx context.Context, pubkey string) (*Webhook, 
 		return nil, err
 	}
 	if len(webhooks) != 1 {
-		return nil, fmt.Errorf("unexpected webhooks count for pubkey: %v", pubkey)
+		return nil, fmt.Errorf("unexpected webhooks count for: %v", identifier)
 	}
 	return &webhooks[0], nil
 }
@@ -106,10 +147,40 @@ func (s *PgStore) DeleteExpired(
 	return err
 }
 
+func (s *PgStore) getPubkeyUsername(ctx context.Context, pubkey []byte) (*PubkeyUsername, error) {
+	rows, err := s.pool.Query(
+		ctx,
+		`SELECT encode(pubkey, 'hex') pubkey, username
+		 FROM public.lnurl_pubkey_usernames
+		 WHERE pubkey = $1`,
+		pubkey,
+	)
+	if err != nil {
+		return nil, err
+	}
+	pubkeyUsername, err := pgx.CollectOneRow(rows, pgx.RowToStructByName[PubkeyUsername])
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return &pubkeyUsername, nil
+}
+
 func pgConnect(databaseUrl string) (*pgxpool.Pool, error) {
 	pgxPool, err := pgxpool.New(context.Background(), databaseUrl)
 	if err != nil {
 		return nil, fmt.Errorf("pgxpool.New(%v): %w", databaseUrl, err)
 	}
 	return pgxPool, nil
+}
+
+func decodeIdentifier(identifier string) *[]byte {
+	pk, err := hex.DecodeString(identifier)
+	if err != nil {
+		return nil
+	}
+
+	return &pk
 }

--- a/persist/pg_test.go
+++ b/persist/pg_test.go
@@ -18,32 +18,60 @@ func TestPgStore(t *testing.T) {
 	assert.NilError(t, pgStore.DeleteExpired(context.Background(), time.Now()), "failed to delete expired")
 
 	// Add a webhook for some pubkey
-	assert.NilError(t,
-		pgStore.Set(context.Background(), Webhook{
-			Pubkey: "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d",
-			Url:    "http://example.com",
-		}),
-		"failed to set webhook")
+	testuser := "testuser"
+	hook, err := pgStore.Set(context.Background(), Webhook{
+		Pubkey: "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d",
+		Url:    "http://example.com",
+		Username: &testuser,
+	})
+	assert.NilError(t, err, "failed to set webhook")
+	assert.Check(t, hook != nil, "hook should not be nil")
+	assert.Equal(t, *hook.Username, "testuser", "username should be testuser")
 
 	// Test that we are able to fetch the right webhook
-	hook, err := pgStore.GetLastUpdated(context.Background(), "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d")
+	hook, err = pgStore.GetLastUpdated(context.Background(), "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d")
 	assert.NilError(t, err, "failed to get webhook from db")
 	assert.Check(t, hook != nil, "hook should not be nil")
 	assert.Equal(t, hook.Pubkey, "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d", "pubkey should be 123")
 
 	// Test that we are not able to attach the same lightning user for different pubkey.
-	assert.NilError(t, pgStore.Set(context.Background(), Webhook{
+	hook, err = pgStore.Set(context.Background(), Webhook{
 		Pubkey: "02de1e98d0f87a1a5d9674f33d997b9c63cb65b27e10319cfa83b1b5ab58913f86",
 		Url:    "http://example.com",
-	}), "should not be able to use same url for different pubkey")
+	})
+	assert.NilError(t, err, "should not be able to use same url for different pubkey")
+	assert.Check(t, hook != nil, "hook should not be nil")
+	assert.Check(t, hook.Username == nil, "hook should be nil")
 
-	// Test that we are able to update the same user registration for the same pubkey.
-	assert.NilError(t,
-		pgStore.Set(context.Background(), Webhook{
-			Pubkey: "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d",
-			Url:    "http://example.com",
-		}),
-		"should be able to update the url for the same pubkey")
+	// Test that we are able to update the same user registration for the same pubkey
+	// and the username is still set.
+	hook, err = pgStore.Set(context.Background(), Webhook{
+		Pubkey: "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d",
+		Url:    "http://example.com",
+	})
+	assert.NilError(t, err, "should be able to update the url for the same pubkey")
+	assert.Check(t, hook != nil, "hook should not be nil")
+	assert.Equal(t, *hook.Username, "testuser", "username should be testuser")
+
+	// Test that we are able to update the same user registration with a different username.
+	differenttestuser := "differenttestuser"
+	hook, err = pgStore.Set(context.Background(), Webhook{
+		Pubkey: "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d",
+		Url:    "http://example.com",
+		Username: &differenttestuser,
+	})
+	assert.NilError(t, err, "should be able to update the url for the same pubkey")
+	assert.Check(t, hook != nil, "hook should not be nil")
+	assert.Equal(t, *hook.Username, "differenttestuser", "username should be differenttestuser")
+
+	// Test that we are not able to set the same username for different pubkey.
+	hook, err = pgStore.Set(context.Background(), Webhook{
+		Pubkey: "02de1e98d0f87a1a5d9674f33d997b9c63cb65b27e10319cfa83b1b5ab58913f86",
+		Url:    "http://example.com",
+		Username: &differenttestuser,
+	})
+	assert.ErrorContains(t, err, "duplicate key value violates unique constraint")
+	assert.Check(t, hook == nil, "hook should be nil")
 
 	assert.NilError(t, pgStore.DeleteExpired(context.Background(), time.Now()), "failed to delete expired")
 }

--- a/persist/pg_test.go
+++ b/persist/pg_test.go
@@ -41,17 +41,16 @@ func TestPgStore(t *testing.T) {
 	})
 	assert.NilError(t, err, "should not be able to use same url for different pubkey")
 	assert.Check(t, hook != nil, "hook should not be nil")
-	assert.Check(t, hook.Username == nil, "hook should be nil")
+	assert.Check(t, hook.Username == nil, "username should be nil")
 
-	// Test that we are able to update the same user registration for the same pubkey
-	// and the username is still set.
+	// Test that we are able to update the same user registration for the same pubkey.
 	hook, err = pgStore.Set(context.Background(), Webhook{
 		Pubkey: "02c811e575be2df47d8b48dab3d3f1c9b0f6e16d0d40b5ed78253308fc2bd7170d",
 		Url:    "http://example.com",
 	})
 	assert.NilError(t, err, "should be able to update the url for the same pubkey")
 	assert.Check(t, hook != nil, "hook should not be nil")
-	assert.Equal(t, *hook.Username, "testuser", "username should be testuser")
+	assert.Check(t, hook.Username == nil, "username should be nil")
 
 	// Test that we are able to update the same user registration with a different username.
 	differenttestuser := "differenttestuser"
@@ -70,7 +69,7 @@ func TestPgStore(t *testing.T) {
 		Url:    "http://example.com",
 		Username: &differenttestuser,
 	})
-	assert.ErrorContains(t, err, "duplicate key value violates unique constraint")
+	assert.ErrorContains(t, err, "invalid username")
 	assert.Check(t, hook == nil, "hook should be nil")
 
 	assert.NilError(t, pgStore.DeleteExpired(context.Background(), time.Now()), "failed to delete expired")


### PR DESCRIPTION
This PR adds the option to register a username along with the pubkey. Registration of the username enables `<username>@<lnurl.domain>` type requests to be handled by the service.

Registration of a username is optional and if included needs to be signed with the request. The username must be unique in that it is not already registered by another pubkey. Registration of another username to the same pubkey will overwrite the existing username. The usernames are stored in a separate table to insure they are not removed during cleaning.