### PR TITLE
Only set verify_url if offer is registered to ensure backwards compatibility

### DIFF
--- a/lnurl/pay.go
+++ b/lnurl/pay.go
@@ -398,14 +398,17 @@ func (l *LnurlPayRouter) HandleInvoice(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	verifyURL := fmt.Sprintf("%v/lnurlpay/%v/{payment_hash}", l.rootURL.String(), identifier)
 	message := channel.WebhookMessage{
 		Template: "lnurlpay_invoice",
 		Data: map[string]interface{}{
-			"amount":     amountNum,
-			"verify_url": verifyURL,
+			"amount": amountNum,
 		},
 	}
+	if webhook.Offer != nil {
+		verifyURL := fmt.Sprintf("%v/lnurlpay/%v/{payment_hash}", l.rootURL.String(), identifier)
+		message.Data["verify_url"] = verifyURL
+	}
+
 	response, err := l.channel.SendRequest(r.Context(), webhook.Url, message, w)
 	if r.Context().Err() != nil {
 		return


### PR DESCRIPTION
This prevents a backwards compatibility issue where the Kotlin serialization of the `lnurlpay_invoice` request cannot be parsed because it contains an unknown `verify_url` key
```
[com.breez.misty.BreezForegroundService] {WARN} (2025-05-13 06:49:21.648) : Failed to process lnurl: Unexpected JSON token at offset 81: Encountered an unknown key 'verify_url' at path: $.reply_url
  Use 'ignoreUnknownKeys = true' in 'Json {}' builder to ignore unknown keys.
  JSON input: {"amount":1000000,"reply_url":"https://breez.fun/response/17913778238782819717","verify_url":"[https://breez.fun/lnurlpay/dangeross/{payment_hash}](https://breez.fun/lnurlpay/dangeross/%7Bpayment_hash%7D)"}
```